### PR TITLE
#58 パンくずリスト修正

### DIFF
--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,5 +1,7 @@
 = render 'shared/main_header'
-= render 'share/breadcrumbs'
+.pankuzu-box
+  - breadcrumb :category, @category
+  = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"
 
 .category_container
   -# ランダムで、11件の子or孫カテゴリーを表示

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -141,8 +141,7 @@
   %nav.bread-crumbs
     %ul
       %li
-        = link_to "メルカリ", "/", class:"bread-crumbs__home-rink"
-        %i.fa.fa-angle-right
-      %li
-        %span コーチ
+        - breadcrumb :item, @item
+        = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"
+
 = render 'shared/main_footer'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -28,3 +28,26 @@ crumb :item do |item|
   link item.name, root_path
   parent :root
 end
+
+crumb :category_index do
+  link "カテゴリー一覧", root_path
+end
+
+crumb :category do |category|
+  # 親カテゴリー
+  if category.is_root?
+    link category.name, category_path(category.id)
+    parent :category_index
+  # 子カテゴリー
+  elsif category.has_children?
+    link category.parent.name, category_path(category.parent.id)
+    link category.name,        category_path(category.id)
+    parent :category_index
+  # 孫カテゴリー
+  else
+    link category.root.name,   category_path(category.root.id)
+    link category.parent.name, category_path(category.parent.id)
+    link category.name,        category_path(category.id)
+    parent :category_index
+  end
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,3 +23,8 @@ crumb :personal_info_regist do
     parent :root
   end
 end
+
+crumb :item do |item|
+  link item.name, root_path
+  parent :root
+end


### PR DESCRIPTION
# What
- カテゴリーのパンくずリスト作成
- 商品詳細のパンくずリスト作成

# Why
- どのページにいるか分かりやすくするため

## カテゴリーの画面イメージ
[![Screenshot from Gyazo](https://gyazo.com/bb201a7cce9db61ff57b430fb05d6936/raw)](https://gyazo.com/bb201a7cce9db61ff57b430fb05d6936)

## 商品詳細の画面イメージ
[![Screenshot from Gyazo](https://gyazo.com/9c8e4c9c3d2b6376927b0d36f5b0ec8e/raw)](https://gyazo.com/9c8e4c9c3d2b6376927b0d36f5b0ec8e)

# Addition
- カテゴリー一覧のページは未実装
- 見た目は別ブランチで修正