### PR TITLE
#114 不具合修正

### DIFF
--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,4 +1,5 @@
 class CardController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_category_list
   before_action :set_brand_list
   before_action :set_payjp_secret_key, except: :new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: :new
-  before_action :set_item,          only: [:show, :edit, :update]
-  before_action :set_category_list, only: [:index, :show]
+  before_action :authenticate_user!,             only: [:new, :edit]
+  before_action :set_item,                       only: [:show, :edit, :update]
+  before_action :set_category_list,              only: [:index, :show]
   before_action :set_item_form_collction_select, only: [:new, :edit, :create]
-  before_action :set_brand_list,    only: [:index, :show]
+  before_action :set_brand_list,                 only: [:index, :show]
 
 
   def show

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,5 +1,6 @@
 class PurchaseController < ApplicationController
   require 'payjp'
+  before_action :authenticate_user!
   before_action :set_payjp_secret_key
   before_action :set_item
   before_action :move_to_root

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,5 +1,5 @@
 class SignupController < ApplicationController
-
+  before_action :move_to_index,     except: [:step5]
   before_action :set_category_list, only: [:step5]
   before_action :set_brand_list,    only: [:step5]
   
@@ -72,6 +72,11 @@ class SignupController < ApplicationController
       :phone_number,
       shipping_address_attributes:[:user_id, :region_id, :postal_code, :address, :building, :city, :building_phone, :created_at, :updated_at]
     )
+  end
+
+  # ログインしていたら、トップページに飛ばす
+  def move_to_index
+    redirect_to root_path if user_signed_in?
   end
 end
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,9 +1,8 @@
 class SignupController < ApplicationController
-  before_action :move_to_index,     except: [:step5]
+  before_action :move_to_index,     except: [:step5]
   before_action :set_category_list, only: [:step5]
   before_action :set_brand_list,    only: [:step5]
   
-
   def step1
     @user = User.new()
   end
@@ -75,8 +74,8 @@ class SignupController < ApplicationController
   end
 
   # ログインしていたら、トップページに飛ばす
-  def move_to_index
-    redirect_to root_path if user_signed_in?
+  def move_to_index
+    redirect_to root_path if user_signed_in?
   end
 end
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,7 +1,8 @@
 class SignupController < ApplicationController
-  before_action :move_to_index,     except: [:step5]
-  before_action :set_category_list, only: [:step5]
-  before_action :set_brand_list,    only: [:step5]
+  before_action :authenticate_user!, only: [:step5] # ログインしていない場合、ログアウトページに入れなくする
+  before_action :move_to_index,      except: [:step5]
+  before_action :set_category_list,  only: [:step5]
+  before_action :set_brand_list,     only: [:step5]
   
   def step1
     @user = User.new()

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :move_to_mypage,    only: [:show]
   before_action :set_category_list, only: [:show, :identification]
   before_action :set_brand_list,    only: [:show, :identification]
 
@@ -10,5 +11,11 @@ class UsersController < ApplicationController
   end
 
   def identification
+  end
+
+  private
+  # 自分以外のマイページに入れないようにする
+  def move_to_mypage
+    redirect_to user_path(current_user.id) unless current_user.id == params[:id].to_i
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: [:show, :identification]
-  before_action :move_to_mypage,     only: [:show, :identification]
-  before_action :set_category_list,  only: [:show, :identification]
-  before_action :set_brand_list,     only: [:show, :identification]
+  before_action :authenticate_user!, only: [:show, :identification, :edit]
+  before_action :move_to_mypage,     only: [:show, :identification, :edit]
+  before_action :set_category_list,  only: [:show, :identification, :edit]
+  before_action :set_brand_list,     only: [:show, :identification, :edit]
 
   def show
     @nickname = current_user.name
@@ -12,6 +12,10 @@ class UsersController < ApplicationController
   end
 
   def identification
+  end
+
+  def edit
+    @user = User.find(params[:id])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
-  before_action :move_to_mypage,    only: [:show]
-  before_action :set_category_list, only: [:show, :identification]
-  before_action :set_brand_list,    only: [:show, :identification]
+  before_action :authenticate_user!, only: [:show, :identification]
+  before_action :move_to_mypage,     only: [:show, :identification]
+  before_action :set_category_list,  only: [:show, :identification]
+  before_action :set_brand_list,     only: [:show, :identification]
 
   def show
     @nickname = current_user.name
@@ -15,12 +16,7 @@ class UsersController < ApplicationController
 
   private
   # 自分以外のマイページに入れないようにする
-  #  ログインしていたら自分のマイページ、していなかったらトップページに飛ばす
   def move_to_mypage
-    if user_signed_in?
-      redirect_to user_path(current_user.id) unless current_user.id == params[:id].to_i
-    else
-      redirect_to root_path
-    end
+    redirect_to user_path(current_user.id) unless current_user.id == params[:id].to_i
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,12 @@ class UsersController < ApplicationController
 
   private
   # 自分以外のマイページに入れないようにする
+  #  ログインしていたら自分のマイページ、していなかったらトップページに飛ばす
   def move_to_mypage
-    redirect_to user_path(current_user.id) unless current_user.id == params[:id].to_i
+    if user_signed_in?
+      redirect_to user_path(current_user.id) unless current_user.id == params[:id].to_i
+    else
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,12 +68,19 @@
         (税込)
       .item-price__container__delivery
         送料込み
-    
-    -# 売り切れてたら売り切れを表示、そうでなければ購入画面に進むボタンを表示
+
+    -# 売り切れていたら、売り切れ表示
     - if @item.buyer_id.present?
       .item-buy-btn{style: "background-color: gray;"} 売り切れ
-    - elsif user_signed_in?
-      = link_to "購入画面に進む", item_purchase_index_path(@item.id), class:"item-buy-btn"
+    - else
+      - if user_signed_in?
+        -# 販売中＆自分が出品した商品でない場合は、購入画面に進むボタン
+        -# 販売中＆自分が出品した商品の場合は、何も表示しない
+        - if @item.saler_id != current_user.id
+          = link_to "購入画面に進む", item_purchase_index_path(@item.id), class:"item-buy-btn"
+      - else
+        -# 販売中＆ログインしていない場合は、購入画面に進むボタンでログイン画面へ遷移
+        = link_to "購入画面に進む", new_user_session_path, class:"item-buy-btn"
 
     -# テキスト表示
     .item-text

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,18 +92,19 @@
           %i.fa.fa-lock
           %span あんしん・あんぜんへの取り組み
 
-  -# 自分の出品した商品で表示されるボタン
-  - if user_signed_in? && @item.saler_id == current_user.id
-    .item-buttons
-      = link_to "商品の編集", edit_item_path(@item.id), class: "item-buttons__edit-button"
-      = link_to "商品の削除", @item, method: :delete, data: { confirm: "アイテム「#{@item.name}」を削除します。よろしいですか？"}, class: "item-buttons__delete-button"
+  - if user_signed_in?
+    -# 自分の出品した商品で表示されるボタン
+    - if @item.saler_id == current_user.id
+      .item-buttons
+        = link_to "商品の編集", edit_item_path(@item.id), class: "item-buttons__edit-button"
+        = link_to "商品の削除", @item, method: :delete, data: { confirm: "アイテム「#{@item.name}」を削除します。よろしいですか？"}, class: "item-buttons__delete-button"
 
-  -# コメント欄
-  .item-comment__container
-    %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-    %textarea
-    %button
-      %span.item-comment__container--submit コメントする
+    -# ログイン時のみ表示されるコメント欄
+    .item-comment__container
+      %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      %textarea
+      %button
+        %span.item-comment__container--submit コメントする
 
   -# アイテムナビ欄
   %ul.item-nav

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -72,7 +72,7 @@
     -# 売り切れてたら売り切れを表示、そうでなければ購入画面に進むボタンを表示
     - if @item.buyer_id.present?
       .item-buy-btn{style: "background-color: gray;"} 売り切れ
-    - else
+    - elsif user_signed_in?
       = link_to "購入画面に進む", item_purchase_index_path(@item.id), class:"item-buy-btn"
 
     -# テキスト表示

--- a/app/views/shared/_main_footer.html.haml
+++ b/app/views/shared/_main_footer.html.haml
@@ -67,7 +67,8 @@
       .footer__content__bottom__icon
       %span.footer__content__bottom__copy-right
         %small © 2019 Mercari
-  = link_to new_item_path do
-    .sell-btn
-      .sell-btn__text 出品
-      %i.sell-btn__icon.fas.fa-camera
+  - if user_signed_in?
+    = link_to new_item_path do
+      .sell-btn
+        .sell-btn__text 出品
+        %i.sell-btn__icon.fas.fa-camera

--- a/app/views/users/_mypage-left.html.haml
+++ b/app/views/users/_mypage-left.html.haml
@@ -3,7 +3,7 @@
     %ul.mypage-menu__nav__list
       /* メニュー1 */
       %li
-        = link_to "/users/#{current_user.id}", class: "mypage-menu__nav__list__item active" do
+        = link_to user_path(current_user.id), class: "mypage-menu__nav__list__item active" do
           マイページ
           #{icon 'fas', 'chevron-right'}
       %li
@@ -19,7 +19,7 @@
           いいね！一覧
           #{icon 'fas', 'chevron-right'}
       %li
-        = link_to "/items/new", class: "mypage-menu__nav__list__item" do
+        = link_to new_item_path, class: "mypage-menu__nav__list__item" do
           出品する
           #{icon 'fas', 'chevron-right'}
       %li
@@ -73,7 +73,7 @@
       %h3.mypage-menu__head 設定
       %ul.mypage-menu__nav__list
         %li
-          = link_to "#", class: "mypage-menu__nav__list__item" do
+          = link_to edit_user_path(current_user.id), class: "mypage-menu__nav__list__item" do
             プロフィール
             #{icon 'fas', 'chevron-right'}
         %li
@@ -81,7 +81,7 @@
             発送元・お届け先住所変更
             #{icon 'fas', 'chevron-right'}
         %li
-          = link_to "/card/show", class: "mypage-menu__nav__list__item" do
+          = link_to card_index_path, class: "mypage-menu__nav__list__item" do
             支払い方法
             #{icon 'fas', 'chevron-right'}
         %li

--- a/app/views/users/_mypage-left.html.haml
+++ b/app/views/users/_mypage-left.html.haml
@@ -97,6 +97,6 @@
             電話番号の確認
             #{icon 'fas', 'chevron-right'}
         %li
-          = link_to "/signup/step5", class: "mypage-menu__nav__list__item" do
+          = link_to logout_path, class: "mypage-menu__nav__list__item" do
             ログアウト
             #{icon 'fas', 'chevron-right'}

--- a/app/views/users/_mypage-right-edit.html.haml
+++ b/app/views/users/_mypage-right-edit.html.haml
@@ -2,12 +2,11 @@
   .mypage-main__profile
   %h2.mypage-main__profile__header
     プロフィール
-  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-    = render "devise/shared/error_messages", resource: resource
+  = form_with model: @user, class: 'profile-edit__form' do |f|
     // アイコンと名前入力欄
     .mypage-main__profile__icon
       = image_tag "member_photo_noimage_thumb.png", class: "mypage-main__profile__icon__image"
-      = f.email_field :email, class: "mypage-main__profile__icon__input", autocomplete: "email", :placeholder => "例）AYA☆セール中"
+      = f.text_field :name, class: "mypage-main__profile__icon__input",:placeholder => "例）AYA☆セール中"
     .mypage-main__profile__contents
       %textarea.mypage-main__profile__contents__text{:name => "introduction", :placeholder => "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
         プロフィールをご覧いただきありがとうございます。

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,5 @@
+= render 'shared/main_header'
+.mypage
+  = render 'users/mypage-left'
+  = render 'users/mypage-right-edit'
+= render 'shared/main_footer'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -12,8 +12,8 @@ crumb :personal_info_regist do
   if current_page?(identification_path)
     link "本人情報の登録", identification_path(current_user)
     parent :mypage
-  elsif current_page?(step5_signup_index_path)
-    link "ログアウト", step5_signup_index_path
+  elsif current_page?(logout_path)
+    link "ログアウト", logout_path
     parent :mypage
   elsif current_page?(card_registration_path)
     link "支払い方法", card_registration_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
 
-  resources  :users,  only: [:show, :destroy]
+  resources  :users,  only: [:show, :destroy, :edit]
   resources  :search, only: [:index]
   resources  :items do
     # items new時の、カテゴリーセレクトボックス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,10 +54,9 @@ Rails.application.routes.draw do
       get  'step2'           => 'signup#step2'
       get  'step3'           => 'signup#step3'
       post 'signup/create'   => 'signup#create'
-      get  'step5'           => 'signup#step5'
     end
   end
-
+  get 'logout' => 'signup#step5'
   get 'identification' => 'users#identification'
   get 'card_registration' => 'buys#card_registration'
 end


### PR DESCRIPTION
# What
#### A. ログイン時、下記の通り修正
1. ユーザー新規登録画面に入れないように修正

#### B. 非ログイン時、下記の通り修正
1. ユーザーマイページに入れないように修正
2. 商品編集ページに入れないように修正
3. ログアウトページに入れないように修正
4. 出品ボタンを非表示にするよう修正
5. 商品詳細ページのコメント欄を非表示に修正
6. クレジットカードのページに入れないように修正
7. 商品購入ページに入れないように修正
8. 商品詳細ページの購入ボタンを非表示に修正

#### C. その他細かい修正
1. プロフィールページへのリンクが無かったため、追加
2. link_toのurlを名前付きヘルパーに修正
3. ログアウトページのURLを変更

# Why
- A. ログイン時、不要な画面に遷移してしまうことを防ぐため
- B. 非ログイン時、ユーザー情報が必要な画面に遷移してしまうことを防ぐため
- C-1. ビューを作成していたが、画面遷移する方法がなかったため
- C-2. URL構造を意識しなくても良くなるため
- C-3. ログアウトページなのにURLがsignup(新規登録)になっていたため